### PR TITLE
ChangeAssignee Command

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -54,7 +54,7 @@ image::startup.png[width="550"]
 . Execute the `signup` command. No other command will work unless you sign up.
 . Execute the `login` command once you've signed up. The GUI should look similar to Figure 2.
 +
-[[launch-app]]
+[[login]]
 [.text-center]
 .Club Connect application after logging in
 image::login.png[width="550"]

--- a/src/main/java/seedu/club/commons/events/ui/SendEmailRequestEvent.java
+++ b/src/main/java/seedu/club/commons/events/ui/SendEmailRequestEvent.java
@@ -7,7 +7,7 @@ import seedu.club.model.email.Subject;
 
 //@@author yash-chowdhary
 /**
- *
+ * Event to send an email.
  */
 public class SendEmailRequestEvent extends BaseEvent {
 

--- a/src/main/java/seedu/club/logic/commands/AssignTaskCommand.java
+++ b/src/main/java/seedu/club/logic/commands/AssignTaskCommand.java
@@ -15,6 +15,7 @@ import seedu.club.model.member.MatricNumber;
 import seedu.club.model.member.exceptions.MemberNotFoundException;
 import seedu.club.model.task.Task;
 import seedu.club.model.task.exceptions.DuplicateTaskException;
+import seedu.club.model.task.exceptions.TaskAlreadyAssignedException;
 
 /**
  * Adds a task to the currently logged-in member's Task list
@@ -45,6 +46,8 @@ public class AssignTaskCommand extends UndoableCommand {
 
     public static final String MESSAGE_SUCCESS = "New task created and assigned to %1$s";
     public static final String MESSAGE_DUPLICATE_TASK = "This task already exists";
+    public static final String MESSAGE_ALREADY_ASSIGNED = "This task has already been assigned to this member by "
+            + "another EXCO member";
     public static final String MESSAGE_MEMBER_NOT_FOUND = "This member doesn't exist in the club book";
 
     private final Task toAdd;
@@ -69,6 +72,8 @@ public class AssignTaskCommand extends UndoableCommand {
             throw new CommandException(MESSAGE_MEMBER_NOT_FOUND);
         } catch (DuplicateTaskException dte) {
             throw new CommandException(MESSAGE_DUPLICATE_TASK);
+        } catch (TaskAlreadyAssignedException e) {
+            throw new CommandException(MESSAGE_ALREADY_ASSIGNED);
         }
     }
 

--- a/src/main/java/seedu/club/logic/commands/ChangeAssigneeCommand.java
+++ b/src/main/java/seedu/club/logic/commands/ChangeAssigneeCommand.java
@@ -1,0 +1,109 @@
+package seedu.club.logic.commands;
+//@@author yash-chowdhary
+import static seedu.club.logic.parser.CliSyntax.PREFIX_MATRIC_NUMBER;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import seedu.club.commons.core.Messages;
+import seedu.club.commons.core.index.Index;
+import seedu.club.logic.commands.exceptions.CommandException;
+import seedu.club.model.member.exceptions.MemberNotFoundException;
+import seedu.club.model.task.Assignee;
+import seedu.club.model.task.Assignor;
+import seedu.club.model.task.Date;
+import seedu.club.model.task.Description;
+import seedu.club.model.task.Status;
+import seedu.club.model.task.Task;
+import seedu.club.model.task.Time;
+import seedu.club.model.task.exceptions.DuplicateTaskException;
+import seedu.club.model.task.exceptions.TaskAlreadyAssignedException;
+
+/**
+ * Changes the Assignee of a specified task.
+ */
+public class ChangeAssigneeCommand extends UndoableCommand {
+
+    public static final String COMMAND_WORD = "changeassignee";
+    public static final ArrayList<String> COMMAND_ALIASES = new ArrayList<>(
+            Arrays.asList(COMMAND_WORD, "assignee")
+    );
+    public static final String COMMAND_FORMAT = COMMAND_WORD + " "
+            + " INDEX " + PREFIX_MATRIC_NUMBER + "MATRIC NUMBER";
+
+    public static final String COMMAND_USAGE = COMMAND_WORD + ": Changes the assignee of the task identified"
+            + " by the index number used in the last task listing.\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + PREFIX_MATRIC_NUMBER + "MATRIC NUMBER\n"
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_MATRIC_NUMBER + "A0123456H";
+
+    public static final String MESSAGE_CHANGE_SUCCESS = "Assignee of task - %1$s, changed successfully to "
+            + "%2$s";
+    public static final String MESSAGE_NOT_CHANGED = "Assignee of task unchanged as the input assignee is "
+            + "same as the identified task's assignee!";
+    public static final String MESSAGE_ALREADY_ASSIGNED = "Assignee of task could not be changed as there is an "
+            + "identical task assigned to this member";
+    public static final String MESSAGE_MEMBER_NOT_FOUND = "This member doesn't exist in the club book";
+
+    private final Index index;
+    private Task taskToEdit;
+    private Task editedTask;
+    private final Assignee newAssignee;
+
+    public ChangeAssigneeCommand(Index index, Assignee newAssignee) {
+        this.index = index;
+        this.newAssignee = newAssignee;
+    }
+
+    @Override
+    protected void preprocessUndoableCommand() throws CommandException {
+        requireToSignUp();
+        requireToLogIn();
+        List<Task> lastShownList = model.getFilteredTaskList();
+
+        if (index.getZeroBased() >= lastShownList.size() || index.getZeroBased() < 0) {
+            throw new CommandException(Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+        }
+
+
+        taskToEdit = lastShownList.get(index.getZeroBased());
+        editedTask = createEditedTask(taskToEdit);
+
+        if (taskToEdit.getAssignee().getAssignee().equalsIgnoreCase(editedTask.getAssignee().getAssignee())) {
+            throw new CommandException(MESSAGE_NOT_CHANGED);
+        }
+    }
+
+    @Override
+    protected CommandResult executeUndoableCommand() throws CommandException {
+        try {
+            model.changeAssignee(taskToEdit, editedTask);
+        } catch (DuplicateTaskException dte) {
+            throw new CommandException(MESSAGE_NOT_CHANGED);
+        } catch (MemberNotFoundException mnfe) {
+            throw new CommandException(MESSAGE_MEMBER_NOT_FOUND);
+        } catch (TaskAlreadyAssignedException e) {
+            throw new CommandException(MESSAGE_ALREADY_ASSIGNED);
+        }
+        return new CommandResult(String.format(MESSAGE_CHANGE_SUCCESS, editedTask.getDescription().getDescription(),
+                newAssignee.getAssignee()));
+    }
+
+    /**
+     * Creates and returns a {@code task} with the details of {@code taskToEdit}
+     * edited with {@code newAssignee}.
+     */
+    private Task createEditedTask(Task taskToEdit) {
+        assert taskToEdit != null;
+
+        Description description = new Description(taskToEdit.getDescription().getDescription());
+        Time time = new Time(taskToEdit.getTime().getTime());
+        Date date = new Date(taskToEdit.getDate().getDate());
+        Assignor assignor = new Assignor(taskToEdit.getAssignor().getAssignor());
+        Status status = new Status(taskToEdit.getStatus().getStatus());
+
+        return new Task(description, time, date, assignor, newAssignee, status);
+    }
+}

--- a/src/main/java/seedu/club/logic/commands/ChangeTaskStatusCommand.java
+++ b/src/main/java/seedu/club/logic/commands/ChangeTaskStatusCommand.java
@@ -20,6 +20,7 @@ import seedu.club.model.task.Task;
 import seedu.club.model.task.Time;
 import seedu.club.model.task.exceptions.DuplicateTaskException;
 import seedu.club.model.task.exceptions.TaskNotFoundException;
+import seedu.club.model.task.exceptions.TaskStatusCannotBeEditedException;
 
 /**
  * Edits the status of a existing task in the club book.
@@ -41,7 +42,7 @@ public class ChangeTaskStatusCommand extends UndoableCommand {
             + PREFIX_STATUS + "Completed";
 
     public static final String MESSAGE_INVALID_PERMISSION = "This task's status cannot be updated "
-            + "as you are not assigned to the task!";
+            + "as you have not assigned this task nor are you assigned to the task !";
     public static final String MESSAGE_CHANGE_SUCCESS = "Status of task - %1$s, successfully changed!";
     public static final String MESSAGE_NOT_CHANGED = "Status of task unchanged as the input status is "
             + "same as the identified task's status!";
@@ -83,6 +84,8 @@ public class ChangeTaskStatusCommand extends UndoableCommand {
             throw new AssertionError("The target task cannot be missing");
         } catch (DuplicateTaskException dte) {
             throw new CommandException(MESSAGE_NOT_CHANGED);
+        } catch (TaskStatusCannotBeEditedException e) {
+            throw new CommandException(MESSAGE_INVALID_PERMISSION);
         }
         return new CommandResult(String.format(MESSAGE_CHANGE_SUCCESS, editedTask.getDescription().getDescription()));
     }

--- a/src/main/java/seedu/club/logic/commands/ChangeTaskStatusCommand.java
+++ b/src/main/java/seedu/club/logic/commands/ChangeTaskStatusCommand.java
@@ -95,10 +95,10 @@ public class ChangeTaskStatusCommand extends UndoableCommand {
         assert taskToEdit != null;
 
         Description description = new Description(taskToEdit.getDescription().getDescription());
+        Time time = new Time(taskToEdit.getTime().getTime());
+        Date date = new Date(taskToEdit.getDate().getDate());
         Assignor assignor = new Assignor(taskToEdit.getAssignor().getAssignor());
         Assignee assignee = new Assignee(taskToEdit.getAssignee().getAssignee());
-        Date date = new Date(taskToEdit.getDate().getDate());
-        Time time = new Time(taskToEdit.getTime().getTime());
 
         return new Task(description, time, date, assignor, assignee, newStatus);
     }

--- a/src/main/java/seedu/club/logic/commands/ViewAllTasksCommand.java
+++ b/src/main/java/seedu/club/logic/commands/ViewAllTasksCommand.java
@@ -6,7 +6,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 
 import seedu.club.logic.commands.exceptions.CommandException;
-import seedu.club.model.task.exceptions.TasksCannotBeDisplayedException;
+import seedu.club.model.task.exceptions.TasksAlreadyListedException;
 
 /**
  * Lists all tasks in the club book to the user.
@@ -22,6 +22,7 @@ public class ViewAllTasksCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "All tasks are displayed.";
     public static final String MESSAGE_CANNOT_VIEW = "You do not have permission to view all tasks.";
+    public static final String MESSAGE_ALREADY_LISTED = "All the tasks in Club Connect are already listed!";
 
     @Override
     public CommandResult execute() throws CommandException {
@@ -31,8 +32,8 @@ public class ViewAllTasksCommand extends Command {
         requireExcoLogIn();
         try {
             model.viewAllTasks();
-        } catch (TasksCannotBeDisplayedException tcbde) {
-            throw new CommandException(MESSAGE_CANNOT_VIEW);
+        } catch (TasksAlreadyListedException e) {
+            throw new CommandException(MESSAGE_ALREADY_LISTED);
         }
         return new CommandResult(MESSAGE_SUCCESS);
     }

--- a/src/main/java/seedu/club/logic/parser/ChangeAssigneeCommandParser.java
+++ b/src/main/java/seedu/club/logic/parser/ChangeAssigneeCommandParser.java
@@ -1,0 +1,40 @@
+package seedu.club.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.club.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.club.logic.parser.CliSyntax.PREFIX_MATRIC_NUMBER;
+
+import seedu.club.commons.core.index.Index;
+import seedu.club.commons.exceptions.IllegalValueException;
+import seedu.club.logic.commands.ChangeAssigneeCommand;
+import seedu.club.logic.parser.exceptions.ParseException;
+import seedu.club.model.member.MatricNumber;
+import seedu.club.model.task.Assignee;
+
+/**
+ * arses input arguments and creates a new ChangeAssignee object
+ */
+public class ChangeAssigneeCommandParser implements Parser<ChangeAssigneeCommand> {
+    @Override
+    public ChangeAssigneeCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_MATRIC_NUMBER);
+
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (IllegalValueException ive) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    ChangeAssigneeCommand.COMMAND_USAGE));
+        }
+
+        try {
+            MatricNumber matricNumber = ParserUtil.parseMatricNumber(argMultimap.getValue(PREFIX_MATRIC_NUMBER)).get();
+            Assignee assignee = new Assignee(matricNumber.toString());
+            return new ChangeAssigneeCommand(index, assignee);
+        } catch (IllegalValueException ive) {
+            throw new ParseException(ive.getMessage(), ive);
+        }
+    }
+}

--- a/src/main/java/seedu/club/logic/parser/ChangeAssigneeCommandParser.java
+++ b/src/main/java/seedu/club/logic/parser/ChangeAssigneeCommandParser.java
@@ -1,5 +1,5 @@
 package seedu.club.logic.parser;
-
+//@@author yash-chowdhary
 import static java.util.Objects.requireNonNull;
 import static seedu.club.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.club.logic.parser.CliSyntax.PREFIX_MATRIC_NUMBER;
@@ -26,7 +26,7 @@ public class ChangeAssigneeCommandParser implements Parser<ChangeAssigneeCommand
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (IllegalValueException ive) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    ChangeAssigneeCommand.COMMAND_USAGE));
+                    ChangeAssigneeCommand.MESSAGE_USAGE));
         }
 
         try {

--- a/src/main/java/seedu/club/logic/parser/ClubBookParser.java
+++ b/src/main/java/seedu/club/logic/parser/ClubBookParser.java
@@ -10,6 +10,7 @@ import seedu.club.logic.commands.AddCommand;
 import seedu.club.logic.commands.AddPollCommand;
 import seedu.club.logic.commands.AddTaskCommand;
 import seedu.club.logic.commands.AssignTaskCommand;
+import seedu.club.logic.commands.ChangeAssigneeCommand;
 import seedu.club.logic.commands.ChangePasswordCommand;
 import seedu.club.logic.commands.ChangeProfilePhotoCommand;
 import seedu.club.logic.commands.ChangeTaskStatusCommand;
@@ -78,6 +79,8 @@ public class ClubBookParser {
             return new AddTaskCommandParser().parse(arguments);
         } else if (isAssignTaskCommand(commandWord)) {
             return new AssignTaskCommandParser().parse(arguments);
+        } else if (isChangeAssigneeCommand(commandWord)) {
+            return new ChangeAssigneeCommandParser().parse(arguments);
         } else if (isChangePasswordCommand(commandWord)) {
             return new ChangePasswordCommandParser().parse(arguments);
         } else if (isChangePicCommand(commandWord)) {
@@ -143,6 +146,18 @@ public class ClubBookParser {
         } else {
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }
+    }
+
+    /**
+     * Returns true if {@code commandWord} matches any of ChangeAssigneeCommand's aliases
+     */
+    private boolean isChangeAssigneeCommand(String commandWord) {
+        for (String commandAlias : ChangeAssigneeCommand.COMMAND_ALIASES) {
+            if (commandWord.equals(commandAlias)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/seedu/club/logic/parser/CommandList.java
+++ b/src/main/java/seedu/club/logic/parser/CommandList.java
@@ -7,6 +7,7 @@ import seedu.club.logic.commands.AddCommand;
 import seedu.club.logic.commands.AddPollCommand;
 import seedu.club.logic.commands.AddTaskCommand;
 import seedu.club.logic.commands.AssignTaskCommand;
+import seedu.club.logic.commands.ChangeAssigneeCommand;
 import seedu.club.logic.commands.ChangePasswordCommand;
 import seedu.club.logic.commands.ChangeProfilePhotoCommand;
 import seedu.club.logic.commands.ChangeTaskStatusCommand;
@@ -83,6 +84,7 @@ public class CommandList {
         commandList.add(ImportCommand.COMMAND_FORMAT);
         commandList.add(ChangePasswordCommand.COMMAND_FORMAT);
         commandList.add(HistoryCommand.COMMAND_WORD);
+        commandList.add(ChangeAssigneeCommand.COMMAND_FORMAT);
 
         Collections.sort(commandList);
         return commandList;

--- a/src/main/java/seedu/club/model/ClubBook.java
+++ b/src/main/java/seedu/club/model/ClubBook.java
@@ -40,6 +40,7 @@ import seedu.club.model.task.Assignor;
 import seedu.club.model.task.Task;
 import seedu.club.model.task.UniqueTaskList;
 import seedu.club.model.task.exceptions.DuplicateTaskException;
+import seedu.club.model.task.exceptions.TaskAlreadyAssignedException;
 import seedu.club.model.task.exceptions.TaskNotFoundException;
 
 /**
@@ -517,14 +518,30 @@ public class ClubBook implements ReadOnlyClubBook {
 
     //@@author yash-chowdhary
     /**
-     * Replaces the given task {@code target} in the list with {@code editedMember}.
+     * Update {@code Task target}'s status with that of {@code Task editedMember}.
      * @throws DuplicateTaskException if updating the tasks's details causes the task to be equivalent to
      *                                  another existing task in the list.
      * @throws TaskNotFoundException if {@code target} could not be found in the list.
      */
-    public void updateTask(Task taskToEdit, Task editedTask) throws DuplicateTaskException, TaskNotFoundException {
+    public void updateTaskStatus(Task taskToEdit, Task editedTask) throws DuplicateTaskException,
+            TaskNotFoundException {
         requireNonNull(editedTask);
         tasks.setTask(taskToEdit, editedTask);
+    }
+
+    /**
+     * Update {@code Task target}'s Assignee with that of {@code Task editedMember}.
+     * @throws DuplicateTaskException if updating the tasks's details causes the task to be equivalent to
+     *                                  another existing task in the list, ignoring the status.
+     * @throws TaskNotFoundException if {@code target} could not be found in the list.
+     */
+    public void updateTaskAssignee(Task taskToEdit, Task editedTask) throws DuplicateTaskException {
+        requireNonNull(editedTask);
+        try {
+            tasks.setTaskIgnoreStatus(taskToEdit, editedTask);
+        } catch (DuplicateTaskException dte) {
+            throw new DuplicateTaskException();
+        }
     }
 
     /**
@@ -553,20 +570,20 @@ public class ClubBook implements ReadOnlyClubBook {
 
                 editedTask = new Task(task.getDescription(), task.getTime(), task.getDate(),
                         newAssignor, newAssignee, task.getStatus());
-                tasks.setTaskEdited(task, editedTask);
+                tasks.setTaskIgnoreStatus(task, editedTask);
                 numberOfTasksUpdated++;
             } else if (task.getAssignor().getAssignor().equalsIgnoreCase(targetMemberMatricNumberString)) {
 
                 Assignor newAssignor = new Assignor(editedMemberMatricNumberString);
                 editedTask = new Task(task.getDescription(), task.getTime(), task.getDate(),
                         newAssignor, task.getAssignee(), task.getStatus());
-                tasks.setTaskEdited(task, editedTask);
+                tasks.setTaskIgnoreStatus(task, editedTask);
                 numberOfTasksUpdated++;
             } else if (task.getAssignee().getAssignee().equalsIgnoreCase(targetMemberMatricNumberString)) {
                 Assignee newAssignee = new Assignee(editedMemberMatricNumberString);
                 editedTask = new Task(task.getDescription(), task.getTime(), task.getDate(),
                         task.getAssignor(), newAssignee, task.getStatus());
-                tasks.setTaskEdited(task, editedTask);
+                tasks.setTaskIgnoreStatus(task, editedTask);
                 numberOfTasksUpdated++;
             }
         }
@@ -590,5 +607,39 @@ public class ClubBook implements ReadOnlyClubBook {
             }
         }
         return numberOfTasksRemoved;
+    }
+
+    /**
+     * Checks if a similar task has been assigned to the member by some other exco member.
+     * The task's Assignor and Status are ignored in this comparison.
+     * @throws TaskAlreadyAssignedException if there exists a task like so.
+     */
+    public void checkIfTaskIsAlreadyAssigned(Task toAdd) throws TaskAlreadyAssignedException {
+        ObservableList<Task> taskObservableList = getTaskList();
+        for (Task task : taskObservableList) {
+            if (task.getDescription().getDescription().equalsIgnoreCase(toAdd.getDescription().getDescription())
+                    && task.getDate().getDate().equalsIgnoreCase(toAdd.getDate().getDate())
+                    && task.getTime().getTime().equalsIgnoreCase(toAdd.getTime().getTime())
+                    && task.getAssignee().getAssignee().equalsIgnoreCase(toAdd.getAssignee().getAssignee())) {
+                throw new TaskAlreadyAssignedException();
+            }
+        }
+    }
+
+    /**
+     * Checks if a similar task exists.
+     * @throws DuplicateTaskException if there exists a duplicate task.
+     */
+    public void checkIfDuplicateTaskExists(Task toAdd) throws DuplicateTaskException {
+        ObservableList<Task> taskObservableList = getTaskList();
+        for (Task task : taskObservableList) {
+            if (task.getDescription().getDescription().equalsIgnoreCase(toAdd.getDescription().getDescription())
+                    && task.getDate().getDate().equalsIgnoreCase(toAdd.getDate().getDate())
+                    && task.getTime().getTime().equalsIgnoreCase(toAdd.getTime().getTime())
+                    && task.getAssignor().getAssignor().equalsIgnoreCase(toAdd.getAssignor().getAssignor())
+                    && task.getAssignee().getAssignee().equalsIgnoreCase(toAdd.getAssignee().getAssignee())) {
+                throw new DuplicateTaskException();
+            }
+        }
     }
 }

--- a/src/main/java/seedu/club/model/Model.java
+++ b/src/main/java/seedu/club/model/Model.java
@@ -32,6 +32,7 @@ import seedu.club.model.task.exceptions.DuplicateTaskException;
 import seedu.club.model.task.exceptions.TaskAlreadyAssignedException;
 import seedu.club.model.task.exceptions.TaskCannotBeDeletedException;
 import seedu.club.model.task.exceptions.TaskNotFoundException;
+import seedu.club.model.task.exceptions.TaskStatusCannotBeEditedException;
 import seedu.club.model.task.exceptions.TasksAlreadyListedException;
 import seedu.club.model.task.exceptions.TasksCannotBeDisplayedException;
 
@@ -248,7 +249,8 @@ public interface Model {
 
     void viewMyTasks() throws TasksAlreadyListedException;
 
-    void changeStatus(Task taskToEdit, Task editedTask) throws TaskNotFoundException, DuplicateTaskException;
+    void changeStatus(Task taskToEdit, Task editedTask) throws TaskNotFoundException, DuplicateTaskException,
+            TaskStatusCannotBeEditedException;
 
     void changeAssignee(Task taskToEdit, Task editedTask) throws MemberNotFoundException, DuplicateTaskException,
             TaskAlreadyAssignedException;

--- a/src/main/java/seedu/club/model/Model.java
+++ b/src/main/java/seedu/club/model/Model.java
@@ -29,6 +29,7 @@ import seedu.club.model.tag.Tag;
 import seedu.club.model.tag.exceptions.TagNotFoundException;
 import seedu.club.model.task.Task;
 import seedu.club.model.task.exceptions.DuplicateTaskException;
+import seedu.club.model.task.exceptions.TaskAlreadyAssignedException;
 import seedu.club.model.task.exceptions.TaskCannotBeDeletedException;
 import seedu.club.model.task.exceptions.TaskNotFoundException;
 import seedu.club.model.task.exceptions.TasksAlreadyListedException;
@@ -242,9 +243,13 @@ public interface Model {
 
     void viewAllTasks() throws TasksCannotBeDisplayedException;
 
-    void assignTask(Task toAdd, MatricNumber matricNumber) throws MemberNotFoundException, DuplicateTaskException;
+    void assignTask(Task toAdd, MatricNumber matricNumber) throws MemberNotFoundException, DuplicateTaskException,
+            TaskAlreadyAssignedException;
 
     void viewMyTasks() throws TasksAlreadyListedException;
 
     void changeStatus(Task taskToEdit, Task editedTask) throws TaskNotFoundException, DuplicateTaskException;
+
+    void changeAssignee(Task taskToEdit, Task editedTask) throws MemberNotFoundException, DuplicateTaskException,
+            TaskAlreadyAssignedException;
 }

--- a/src/main/java/seedu/club/model/Model.java
+++ b/src/main/java/seedu/club/model/Model.java
@@ -30,11 +30,11 @@ import seedu.club.model.tag.exceptions.TagNotFoundException;
 import seedu.club.model.task.Task;
 import seedu.club.model.task.exceptions.DuplicateTaskException;
 import seedu.club.model.task.exceptions.TaskAlreadyAssignedException;
+import seedu.club.model.task.exceptions.TaskAssigneeUnchangedException;
 import seedu.club.model.task.exceptions.TaskCannotBeDeletedException;
 import seedu.club.model.task.exceptions.TaskNotFoundException;
 import seedu.club.model.task.exceptions.TaskStatusCannotBeEditedException;
 import seedu.club.model.task.exceptions.TasksAlreadyListedException;
-import seedu.club.model.task.exceptions.TasksCannotBeDisplayedException;
 
 /**
  * The API of the Model component.
@@ -242,7 +242,7 @@ public interface Model {
     void setClearConfirmation(Boolean b);
     //@@author
 
-    void viewAllTasks() throws TasksCannotBeDisplayedException;
+    void viewAllTasks() throws TasksAlreadyListedException;
 
     void assignTask(Task toAdd, MatricNumber matricNumber) throws MemberNotFoundException, DuplicateTaskException,
             TaskAlreadyAssignedException;
@@ -253,5 +253,5 @@ public interface Model {
             TaskStatusCannotBeEditedException;
 
     void changeAssignee(Task taskToEdit, Task editedTask) throws MemberNotFoundException, DuplicateTaskException,
-            TaskAlreadyAssignedException;
+            TaskAlreadyAssignedException, TaskAssigneeUnchangedException;
 }

--- a/src/main/java/seedu/club/model/ModelManager.java
+++ b/src/main/java/seedu/club/model/ModelManager.java
@@ -25,6 +25,7 @@ import seedu.club.commons.events.model.ProfilePhotoChangedEvent;
 import seedu.club.commons.events.ui.SendEmailRequestEvent;
 import seedu.club.commons.exceptions.PhotoReadException;
 import seedu.club.commons.util.CsvUtil;
+import seedu.club.logic.commands.ViewAllTasksCommand;
 import seedu.club.logic.commands.ViewMyTasksCommand;
 import seedu.club.model.email.Body;
 import seedu.club.model.email.Client;
@@ -55,11 +56,11 @@ import seedu.club.model.task.Task;
 import seedu.club.model.task.TaskIsRelatedToMemberPredicate;
 import seedu.club.model.task.exceptions.DuplicateTaskException;
 import seedu.club.model.task.exceptions.TaskAlreadyAssignedException;
+import seedu.club.model.task.exceptions.TaskAssigneeUnchangedException;
 import seedu.club.model.task.exceptions.TaskCannotBeDeletedException;
 import seedu.club.model.task.exceptions.TaskNotFoundException;
 import seedu.club.model.task.exceptions.TaskStatusCannotBeEditedException;
 import seedu.club.model.task.exceptions.TasksAlreadyListedException;
-import seedu.club.model.task.exceptions.TasksCannotBeDisplayedException;
 import seedu.club.storage.CsvClubBookStorage;
 
 /**
@@ -333,7 +334,7 @@ public class ModelManager extends ComponentManager implements Model {
 
     @Override
     public void changeAssignee(Task taskToEdit, Task editedTask) throws DuplicateTaskException,
-            MemberNotFoundException, TaskAlreadyAssignedException {
+            MemberNotFoundException, TaskAlreadyAssignedException, TaskAssigneeUnchangedException {
         requireAllNonNull(taskToEdit, editedTask);
         MatricNumber newAssigneeMatricNumber = new MatricNumber(editedTask.getAssignee().getAssignee());
         checkIfMemberExists(newAssigneeMatricNumber);
@@ -349,9 +350,9 @@ public class ModelManager extends ComponentManager implements Model {
         indicateClubBookChanged();
     }
 
-    private void checkIfInputAssigneeIsSame(Task taskToEdit, Task editedTask) throws DuplicateTaskException {
+    private void checkIfInputAssigneeIsSame(Task taskToEdit, Task editedTask) throws TaskAssigneeUnchangedException {
         if (taskToEdit.getAssignee().equals(editedTask.getAssignee())) {
-            throw new DuplicateTaskException();
+            throw new TaskAssigneeUnchangedException();
         }
     }
 
@@ -453,9 +454,16 @@ public class ModelManager extends ComponentManager implements Model {
     }
 
     @Override
-    public void viewAllTasks() throws TasksCannotBeDisplayedException {
+    public void viewAllTasks() throws TasksAlreadyListedException {
+        checkIfAllTasksAlreadyListed();
         updateFilteredTaskList(PREDICATE_SHOW_ALL_TASKS);
         indicateClubBookChanged();
+    }
+
+    private void checkIfAllTasksAlreadyListed() throws TasksAlreadyListedException {
+        if (filteredTasks.getPredicate().equals(PREDICATE_SHOW_ALL_TASKS)) {
+            throw new TasksAlreadyListedException(ViewAllTasksCommand.MESSAGE_ALREADY_LISTED);
+        }
     }
 
     @Override

--- a/src/main/java/seedu/club/model/ModelManager.java
+++ b/src/main/java/seedu/club/model/ModelManager.java
@@ -57,6 +57,7 @@ import seedu.club.model.task.exceptions.DuplicateTaskException;
 import seedu.club.model.task.exceptions.TaskAlreadyAssignedException;
 import seedu.club.model.task.exceptions.TaskCannotBeDeletedException;
 import seedu.club.model.task.exceptions.TaskNotFoundException;
+import seedu.club.model.task.exceptions.TaskStatusCannotBeEditedException;
 import seedu.club.model.task.exceptions.TasksAlreadyListedException;
 import seedu.club.model.task.exceptions.TasksCannotBeDisplayedException;
 import seedu.club.storage.CsvClubBookStorage;
@@ -309,11 +310,25 @@ public class ModelManager extends ComponentManager implements Model {
 
     @Override
     public void changeStatus(Task taskToEdit, Task editedTask) throws TaskNotFoundException,
-            DuplicateTaskException {
+            DuplicateTaskException, TaskStatusCannotBeEditedException {
         requireAllNonNull(taskToEdit, editedTask);
+        String currentMember = getLoggedInMember().getMatricNumber().toString();
+        checkIfStatusCanBeEdited(taskToEdit, currentMember);
         clubBook.updateTaskStatus(taskToEdit, editedTask);
         updateFilteredTaskList(new TaskIsRelatedToMemberPredicate(getLoggedInMember()));
         indicateClubBookChanged();
+    }
+
+    /**
+     * Checks if status can be edited based on the current member's matric number.
+     * @throws TaskStatusCannotBeEditedException if the task status cannot be edited.
+     */
+    private void checkIfStatusCanBeEdited(Task taskToEdit, String currentMember)
+            throws TaskStatusCannotBeEditedException {
+        if (!currentMember.equalsIgnoreCase(taskToEdit.getAssignor().getAssignor())
+                && !currentMember.equalsIgnoreCase(taskToEdit.getAssignee().getAssignee())) {
+            throw new TaskStatusCannotBeEditedException();
+        }
     }
 
     @Override

--- a/src/main/java/seedu/club/model/task/UniqueTaskList.java
+++ b/src/main/java/seedu/club/model/task/UniqueTaskList.java
@@ -78,7 +78,7 @@ public class UniqueTaskList implements Iterable<Task> {
         internalList.set(index, editedTask);
     }
 
-    public void setTaskEdited(Task target, Task editedTask) throws DuplicateTaskException {
+    public void setTaskIgnoreStatus(Task target, Task editedTask) throws DuplicateTaskException {
         requireNonNull(editedTask);
 
         int index = internalList.indexOf(target);

--- a/src/main/java/seedu/club/model/task/exceptions/TaskAlreadyAssignedException.java
+++ b/src/main/java/seedu/club/model/task/exceptions/TaskAlreadyAssignedException.java
@@ -1,0 +1,7 @@
+package seedu.club.model.task.exceptions;
+
+/**
+ * Signals that a member has already been assigned this task.
+ */
+public class TaskAlreadyAssignedException extends Exception {
+}

--- a/src/main/java/seedu/club/model/task/exceptions/TaskAssigneeUnchangedException.java
+++ b/src/main/java/seedu/club/model/task/exceptions/TaskAssigneeUnchangedException.java
@@ -1,0 +1,7 @@
+package seedu.club.model.task.exceptions;
+
+/**
+ * Signals that the input assignee is the same as the identified task's assignee.
+ */
+public class TaskAssigneeUnchangedException extends Exception {
+}

--- a/src/main/java/seedu/club/model/task/exceptions/TaskStatusCannotBeEditedException.java
+++ b/src/main/java/seedu/club/model/task/exceptions/TaskStatusCannotBeEditedException.java
@@ -1,0 +1,7 @@
+package seedu.club.model.task.exceptions;
+
+/**
+ * Signals that a task's status cannot be edited because of invalid permissions.
+ */
+public class TaskStatusCannotBeEditedException extends Exception {
+}

--- a/src/test/java/seedu/club/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/club/logic/commands/AddCommandTest.java
@@ -53,7 +53,6 @@ import seedu.club.model.task.exceptions.TaskAlreadyAssignedException;
 import seedu.club.model.task.exceptions.TaskCannotBeDeletedException;
 import seedu.club.model.task.exceptions.TaskNotFoundException;
 import seedu.club.model.task.exceptions.TasksAlreadyListedException;
-import seedu.club.model.task.exceptions.TasksCannotBeDisplayedException;
 import seedu.club.testutil.MemberBuilder;
 
 public class AddCommandTest {
@@ -161,7 +160,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public void viewAllTasks() throws TasksCannotBeDisplayedException {
+        public void viewAllTasks() throws TasksAlreadyListedException {
             fail("This method should not be called.");
         }
 

--- a/src/test/java/seedu/club/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/club/logic/commands/AddCommandTest.java
@@ -49,6 +49,7 @@ import seedu.club.model.tag.Tag;
 import seedu.club.model.tag.exceptions.TagNotFoundException;
 import seedu.club.model.task.Task;
 import seedu.club.model.task.exceptions.DuplicateTaskException;
+import seedu.club.model.task.exceptions.TaskAlreadyAssignedException;
 import seedu.club.model.task.exceptions.TaskCannotBeDeletedException;
 import seedu.club.model.task.exceptions.TaskNotFoundException;
 import seedu.club.model.task.exceptions.TasksAlreadyListedException;
@@ -145,6 +146,12 @@ public class AddCommandTest {
         public FilteredList<Poll> getFilteredPollList() {
             fail("This method should not be called.");
             return null;
+        }
+
+        @Override
+        public void changeAssignee(Task taskToEdit, Task editedTask) throws MemberNotFoundException,
+                DuplicateTaskException, TaskAlreadyAssignedException {
+            fail("This method should not be called");
         }
 
         @Override

--- a/src/test/java/seedu/club/logic/commands/AddPollCommandTest.java
+++ b/src/test/java/seedu/club/logic/commands/AddPollCommandTest.java
@@ -53,7 +53,6 @@ import seedu.club.model.task.exceptions.TaskAlreadyAssignedException;
 import seedu.club.model.task.exceptions.TaskCannotBeDeletedException;
 import seedu.club.model.task.exceptions.TaskNotFoundException;
 import seedu.club.model.task.exceptions.TasksAlreadyListedException;
-import seedu.club.model.task.exceptions.TasksCannotBeDisplayedException;
 import seedu.club.testutil.PollBuilder;
 
 public class AddPollCommandTest {
@@ -161,7 +160,7 @@ public class AddPollCommandTest {
         }
 
         @Override
-        public void viewAllTasks() throws TasksCannotBeDisplayedException {
+        public void viewAllTasks() throws TasksAlreadyListedException {
             fail("This method should not be called");
         }
 

--- a/src/test/java/seedu/club/logic/commands/AddPollCommandTest.java
+++ b/src/test/java/seedu/club/logic/commands/AddPollCommandTest.java
@@ -49,6 +49,7 @@ import seedu.club.model.tag.Tag;
 import seedu.club.model.tag.exceptions.TagNotFoundException;
 import seedu.club.model.task.Task;
 import seedu.club.model.task.exceptions.DuplicateTaskException;
+import seedu.club.model.task.exceptions.TaskAlreadyAssignedException;
 import seedu.club.model.task.exceptions.TaskCannotBeDeletedException;
 import seedu.club.model.task.exceptions.TaskNotFoundException;
 import seedu.club.model.task.exceptions.TasksAlreadyListedException;
@@ -145,6 +146,12 @@ public class AddPollCommandTest {
         @Override
         public void changeStatus(Task taskToEdit, Task editedTask) throws TaskNotFoundException,
                 DuplicateTaskException {
+            fail("This method should not be called");
+        }
+
+        @Override
+        public void changeAssignee(Task taskToEdit, Task editedTask) throws MemberNotFoundException,
+                DuplicateTaskException, TaskAlreadyAssignedException {
             fail("This method should not be called");
         }
 

--- a/src/test/java/seedu/club/logic/commands/AddTaskCommandTest.java
+++ b/src/test/java/seedu/club/logic/commands/AddTaskCommandTest.java
@@ -50,6 +50,7 @@ import seedu.club.model.tag.Tag;
 import seedu.club.model.tag.exceptions.TagNotFoundException;
 import seedu.club.model.task.Task;
 import seedu.club.model.task.exceptions.DuplicateTaskException;
+import seedu.club.model.task.exceptions.TaskAlreadyAssignedException;
 import seedu.club.model.task.exceptions.TaskCannotBeDeletedException;
 import seedu.club.model.task.exceptions.TaskNotFoundException;
 import seedu.club.model.task.exceptions.TasksAlreadyListedException;
@@ -142,6 +143,12 @@ public class AddTaskCommandTest {
         @Override
         public void changeStatus(Task taskToEdit, Task editedTask) throws TaskNotFoundException,
                 DuplicateTaskException {
+            fail("This method should not be called");
+        }
+
+        @Override
+        public void changeAssignee(Task taskToEdit, Task editedTask) throws MemberNotFoundException,
+                DuplicateTaskException, TaskAlreadyAssignedException {
             fail("This method should not be called");
         }
 

--- a/src/test/java/seedu/club/logic/commands/AddTaskCommandTest.java
+++ b/src/test/java/seedu/club/logic/commands/AddTaskCommandTest.java
@@ -54,7 +54,6 @@ import seedu.club.model.task.exceptions.TaskAlreadyAssignedException;
 import seedu.club.model.task.exceptions.TaskCannotBeDeletedException;
 import seedu.club.model.task.exceptions.TaskNotFoundException;
 import seedu.club.model.task.exceptions.TasksAlreadyListedException;
-import seedu.club.model.task.exceptions.TasksCannotBeDisplayedException;
 import seedu.club.testutil.TaskBuilder;
 
 //@@author yash-chowdhary
@@ -164,7 +163,7 @@ public class AddTaskCommandTest {
         }
 
         @Override
-        public void viewAllTasks() throws TasksCannotBeDisplayedException {
+        public void viewAllTasks() throws TasksAlreadyListedException {
             fail("This method should not be called");
         }
 

--- a/src/test/java/seedu/club/logic/commands/AssignTaskCommandTest.java
+++ b/src/test/java/seedu/club/logic/commands/AssignTaskCommandTest.java
@@ -54,6 +54,7 @@ import seedu.club.model.tag.Tag;
 import seedu.club.model.tag.exceptions.TagNotFoundException;
 import seedu.club.model.task.Task;
 import seedu.club.model.task.exceptions.DuplicateTaskException;
+import seedu.club.model.task.exceptions.TaskAlreadyAssignedException;
 import seedu.club.model.task.exceptions.TaskCannotBeDeletedException;
 import seedu.club.model.task.exceptions.TaskNotFoundException;
 import seedu.club.model.task.exceptions.TasksAlreadyListedException;
@@ -161,6 +162,12 @@ public class AssignTaskCommandTest {
         @Override
         public void changeStatus(Task taskToEdit, Task editedTask) throws TaskNotFoundException,
                 DuplicateTaskException {
+            fail("This method should not be called");
+        }
+
+        @Override
+        public void changeAssignee(Task taskToEdit, Task editedTask) throws MemberNotFoundException,
+                DuplicateTaskException, TaskAlreadyAssignedException {
             fail("This method should not be called");
         }
 

--- a/src/test/java/seedu/club/logic/commands/AssignTaskCommandTest.java
+++ b/src/test/java/seedu/club/logic/commands/AssignTaskCommandTest.java
@@ -58,7 +58,6 @@ import seedu.club.model.task.exceptions.TaskAlreadyAssignedException;
 import seedu.club.model.task.exceptions.TaskCannotBeDeletedException;
 import seedu.club.model.task.exceptions.TaskNotFoundException;
 import seedu.club.model.task.exceptions.TasksAlreadyListedException;
-import seedu.club.model.task.exceptions.TasksCannotBeDisplayedException;
 import seedu.club.testutil.TaskBuilder;
 
 public class AssignTaskCommandTest {
@@ -183,7 +182,7 @@ public class AssignTaskCommandTest {
         }
 
         @Override
-        public void viewAllTasks() throws TasksCannotBeDisplayedException {
+        public void viewAllTasks() throws TasksAlreadyListedException {
             fail("This method should not be called");
         }
 

--- a/src/test/java/seedu/club/logic/commands/ChangeAssigneeCommandTest.java
+++ b/src/test/java/seedu/club/logic/commands/ChangeAssigneeCommandTest.java
@@ -75,10 +75,10 @@ public class ChangeAssigneeCommandTest {
         ClubBook expectedClubBook = new ClubBookBuilder().withMember(alice).withMember(benson).withTask(buyFood)
                 .withTask(bookAuditorium).build();
 
-        expectedModel = new ModelManager(expectedClubBook, new UserPrefs());
+        model.changeAssignee(BUY_FOOD, buyFood);
+        expectedModel = new ModelManager(model.getClubBook(), new UserPrefs());
         expectedModel.logsInMember(ALICE.getCredentials().getUsername().value,
                 ALICE.getCredentials().getPassword().value);
-        model.changeAssignee(BUY_FOOD, buyFood);
 
         assertEquals(expectedModel, model);
     }
@@ -94,7 +94,7 @@ public class ChangeAssigneeCommandTest {
         Task editedTask = new TaskBuilder(buyFood).build();
         editedTask.setAssignee(new Assignee(CARL.getMatricNumber().toString()));
 
-        expectedModel = new ModelManager(expectedClubBook, new UserPrefs());
+        expectedModel = new ModelManager(model.getClubBook(), new UserPrefs());
         expectedModel.logsInMember(ALICE.getCredentials().getUsername().value,
                 ALICE.getCredentials().getPassword().value);
         try {

--- a/src/test/java/seedu/club/logic/commands/ChangeAssigneeCommandTest.java
+++ b/src/test/java/seedu/club/logic/commands/ChangeAssigneeCommandTest.java
@@ -1,0 +1,195 @@
+package seedu.club.logic.commands;
+//@@author yash-chowdhary
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static seedu.club.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.club.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.club.logic.commands.CommandTestUtil.prepareRedoCommand;
+import static seedu.club.logic.commands.CommandTestUtil.prepareUndoCommand;
+import static seedu.club.testutil.TypicalIndexes.INDEX_FIRST_TASK;
+import static seedu.club.testutil.TypicalMembers.ALICE;
+import static seedu.club.testutil.TypicalMembers.BENSON;
+import static seedu.club.testutil.TypicalMembers.CARL;
+import static seedu.club.testutil.TypicalTasks.BOOK_AUDITORIUM;
+import static seedu.club.testutil.TypicalTasks.BUY_FOOD;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import seedu.club.commons.core.Messages;
+import seedu.club.commons.core.index.Index;
+import seedu.club.logic.CommandHistory;
+import seedu.club.logic.UndoRedoStack;
+import seedu.club.model.ClubBook;
+import seedu.club.model.Model;
+import seedu.club.model.ModelManager;
+import seedu.club.model.UserPrefs;
+import seedu.club.model.member.Member;
+import seedu.club.model.member.exceptions.MemberNotFoundException;
+import seedu.club.model.task.Assignee;
+import seedu.club.model.task.Task;
+import seedu.club.model.task.exceptions.DuplicateTaskException;
+import seedu.club.model.task.exceptions.TaskAlreadyAssignedException;
+import seedu.club.model.task.exceptions.TaskAssigneeUnchangedException;
+import seedu.club.testutil.ClubBookBuilder;
+import seedu.club.testutil.MemberBuilder;
+import seedu.club.testutil.TaskBuilder;
+
+public class ChangeAssigneeCommandTest {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private Model model;
+    private Model expectedModel;
+
+    @Before
+    public void setUp() {
+        ClubBook clubBook = new ClubBookBuilder().withMember(ALICE).withMember(BENSON).withTask(BUY_FOOD)
+                .withTask(BOOK_AUDITORIUM).build();
+        model = new ModelManager(clubBook, new UserPrefs());
+        model.logsInMember(ALICE.getCredentials().getUsername().value,
+                ALICE.getCredentials().getPassword().value);
+    }
+
+    @Test
+    public void constructor_nullTask_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        new ChangeAssigneeCommand(null, null);
+    }
+
+    @Test
+    public void execute_validAssignee_success() throws Exception {
+        Member alice = new MemberBuilder(ALICE).build();
+        Member benson = new MemberBuilder(BENSON).build();
+        Task buyFood = new TaskBuilder().withDescription(BUY_FOOD.getDescription().getDescription())
+                .withDate(BUY_FOOD.getDate().getDate())
+                .withTime(BUY_FOOD.getTime().getTime())
+                .withAssignor(alice.getMatricNumber().toString())
+                .withAssignee(benson.getMatricNumber().toString())
+                .withStatus(BUY_FOOD.getStatus().getStatus())
+                .build();
+        Task bookAuditorium = new TaskBuilder(BOOK_AUDITORIUM).build();
+        ClubBook expectedClubBook = new ClubBookBuilder().withMember(alice).withMember(benson).withTask(buyFood)
+                .withTask(bookAuditorium).build();
+
+        expectedModel = new ModelManager(expectedClubBook, new UserPrefs());
+        expectedModel.logsInMember(ALICE.getCredentials().getUsername().value,
+                ALICE.getCredentials().getPassword().value);
+        model.changeAssignee(BUY_FOOD, buyFood);
+
+        assertEquals(expectedModel, model);
+    }
+
+    @Test
+    public void execute_invalidAssignee_throwsException() {
+        Member alice = new MemberBuilder(ALICE).build();
+        Member benson = new MemberBuilder(BENSON).build();
+        Task buyFood = new TaskBuilder(BUY_FOOD).build();
+        Task bookAuditorium = new TaskBuilder(BOOK_AUDITORIUM).build();
+        ClubBook expectedClubBook = new ClubBookBuilder().withMember(alice).withMember(benson).withTask(buyFood)
+                .withTask(bookAuditorium).build();
+        Task editedTask = new TaskBuilder(buyFood).build();
+        editedTask.setAssignee(new Assignee(CARL.getMatricNumber().toString()));
+
+        expectedModel = new ModelManager(expectedClubBook, new UserPrefs());
+        expectedModel.logsInMember(ALICE.getCredentials().getUsername().value,
+                ALICE.getCredentials().getPassword().value);
+        try {
+            model.changeAssignee(BUY_FOOD, editedTask);
+        } catch (MemberNotFoundException mnfe) {
+            assertEquals(expectedModel, model);
+        } catch (DuplicateTaskException | TaskAlreadyAssignedException | TaskAssigneeUnchangedException e) {
+            return;
+        }
+    }
+
+    @Test
+    public void executeUndoRedo_validIndexUnfilteredList_success() throws Exception {
+        ClubBook expectedClubBook = new ClubBookBuilder().withMember(ALICE).withMember(BENSON).withTask(BUY_FOOD)
+                .withTask(BOOK_AUDITORIUM).build();
+
+        UndoRedoStack undoRedoStack = new UndoRedoStack();
+        UndoCommand undoCommand = prepareUndoCommand(model, undoRedoStack);
+        RedoCommand redoCommand = prepareRedoCommand(model, undoRedoStack);
+
+        Task taskToEdit = new TaskBuilder(BUY_FOOD).build();
+        Task editedTask = new TaskBuilder(taskToEdit).build();
+        editedTask.setAssignee(new Assignee(BENSON.getMatricNumber().toString()));
+        ChangeAssigneeCommand changeAssigneeCommand = prepareCommand(INDEX_FIRST_TASK,
+                new Assignee(BENSON.getMatricNumber().toString()));
+
+        expectedModel = new ModelManager(expectedClubBook, new UserPrefs());
+        expectedModel.logsInMember(ALICE.getCredentials().getUsername().value,
+                ALICE.getCredentials().getPassword().value);
+
+        changeAssigneeCommand.execute();
+        undoRedoStack.push(changeAssigneeCommand);
+        assertCommandSuccess(undoCommand, model, UndoCommand.MESSAGE_SUCCESS, expectedModel);
+
+        expectedModel.changeAssignee(taskToEdit, editedTask);
+        assertCommandSuccess(redoCommand, model, RedoCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void executeUndoRedo_invalidIndexUnfilteredList_failure() {
+        UndoRedoStack undoRedoStack = new UndoRedoStack();
+        UndoCommand undoCommand = prepareUndoCommand(model, undoRedoStack);
+        RedoCommand redoCommand = prepareRedoCommand(model, undoRedoStack);
+
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredTaskList().size() + 1);
+        ChangeAssigneeCommand changeAssigneeCommand = prepareCommand(outOfBoundIndex,
+                new Assignee(BENSON.getMatricNumber().toString()));
+
+        assertCommandFailure(changeAssigneeCommand, model, Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+
+        assertCommandFailure(undoCommand, model, UndoCommand.MESSAGE_FAILURE);
+        assertCommandFailure(redoCommand, model, RedoCommand.MESSAGE_FAILURE);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() throws Exception {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredTaskList().size() + 1);
+        ChangeAssigneeCommand changeAssigneeCommand = prepareCommand(outOfBoundIndex,
+                new Assignee(BENSON.getMatricNumber().toString()));
+
+        assertCommandFailure(changeAssigneeCommand, model, Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+    }
+
+    private ChangeAssigneeCommand prepareCommand(Index index, Assignee assignee) {
+        ChangeAssigneeCommand changeAssigneeCommand = new ChangeAssigneeCommand(index, assignee);
+        changeAssigneeCommand.setData(model, new CommandHistory(), new UndoRedoStack());
+        return changeAssigneeCommand;
+    }
+
+    @Test
+    public void equals() throws Exception {
+        ChangeAssigneeCommand changeAssigneeFirstCommand = prepareCommand(INDEX_FIRST_TASK,
+                new Assignee(BENSON.getMatricNumber().toString()));
+        ChangeAssigneeCommand changeAssigneeSecondCommand = prepareCommand(INDEX_FIRST_TASK,
+                new Assignee(CARL.getMatricNumber().toString()));
+
+        changeAssigneeFirstCommand.preprocessUndoableCommand();
+        changeAssigneeSecondCommand.preprocessUndoableCommand();
+
+        // same object -> returns true
+        assertTrue(changeAssigneeFirstCommand.equals(changeAssigneeFirstCommand));
+
+        // same values -> returns true
+        ChangeAssigneeCommand changeAssigneeFirstCommandCopy = prepareCommand(INDEX_FIRST_TASK,
+                new Assignee(BENSON.getMatricNumber().toString()));
+        assertTrue(changeAssigneeFirstCommand.equals(changeAssigneeFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(changeAssigneeFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(changeAssigneeFirstCommand.equals(null));
+
+        // different member -> returns false
+        assertFalse(changeAssigneeFirstCommand.equals(changeAssigneeSecondCommand));
+    }
+
+}

--- a/src/test/java/seedu/club/logic/commands/ChangeProfilePhotoCommandTest.java
+++ b/src/test/java/seedu/club/logic/commands/ChangeProfilePhotoCommandTest.java
@@ -51,6 +51,7 @@ import seedu.club.model.tag.Tag;
 import seedu.club.model.tag.exceptions.TagNotFoundException;
 import seedu.club.model.task.Task;
 import seedu.club.model.task.exceptions.DuplicateTaskException;
+import seedu.club.model.task.exceptions.TaskAlreadyAssignedException;
 import seedu.club.model.task.exceptions.TaskCannotBeDeletedException;
 import seedu.club.model.task.exceptions.TaskNotFoundException;
 import seedu.club.model.task.exceptions.TasksAlreadyListedException;
@@ -156,6 +157,12 @@ public class ChangeProfilePhotoCommandTest {
         @Override
         public void changeStatus(Task taskToEdit, Task editedTask) throws TaskNotFoundException,
                 DuplicateTaskException {
+            fail("This method should not be called");
+        }
+
+        @Override
+        public void changeAssignee(Task taskToEdit, Task editedTask) throws MemberNotFoundException,
+                DuplicateTaskException, TaskAlreadyAssignedException {
             fail("This method should not be called");
         }
 

--- a/src/test/java/seedu/club/logic/commands/ChangeProfilePhotoCommandTest.java
+++ b/src/test/java/seedu/club/logic/commands/ChangeProfilePhotoCommandTest.java
@@ -55,7 +55,6 @@ import seedu.club.model.task.exceptions.TaskAlreadyAssignedException;
 import seedu.club.model.task.exceptions.TaskCannotBeDeletedException;
 import seedu.club.model.task.exceptions.TaskNotFoundException;
 import seedu.club.model.task.exceptions.TasksAlreadyListedException;
-import seedu.club.model.task.exceptions.TasksCannotBeDisplayedException;
 
 public class ChangeProfilePhotoCommandTest {
 
@@ -224,7 +223,7 @@ public class ChangeProfilePhotoCommandTest {
         }
 
         @Override
-        public void viewAllTasks() throws TasksCannotBeDisplayedException {
+        public void viewAllTasks() throws TasksAlreadyListedException {
             fail("This method should not be called");
         }
 

--- a/src/test/java/seedu/club/logic/commands/ChangeTaskStatusCommandTest.java
+++ b/src/test/java/seedu/club/logic/commands/ChangeTaskStatusCommandTest.java
@@ -49,7 +49,7 @@ public class ChangeTaskStatusCommandTest {
     @Test
     public void constructor_nullTask_throwsNullPointerException() {
         thrown.expect(NullPointerException.class);
-        new AssignTaskCommand(null, null);
+        new ChangeTaskStatusCommand(null, null);
     }
 
     @Test

--- a/src/test/java/seedu/club/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/club/logic/commands/ExportCommandTest.java
@@ -51,6 +51,7 @@ import seedu.club.model.tag.Tag;
 import seedu.club.model.tag.exceptions.TagNotFoundException;
 import seedu.club.model.task.Task;
 import seedu.club.model.task.exceptions.DuplicateTaskException;
+import seedu.club.model.task.exceptions.TaskAlreadyAssignedException;
 import seedu.club.model.task.exceptions.TaskCannotBeDeletedException;
 import seedu.club.model.task.exceptions.TaskNotFoundException;
 import seedu.club.model.task.exceptions.TasksAlreadyListedException;
@@ -152,6 +153,12 @@ public class ExportCommandTest {
         public void voteInPoll(Poll poll, Index answerIndex) throws
                 PollNotFoundException, AnswerNotFoundException, UserAlreadyVotedException {
             fail("This method should not be called.");
+        }
+
+        @Override
+        public void changeAssignee(Task taskToEdit, Task editedTask) throws MemberNotFoundException,
+                DuplicateTaskException, TaskAlreadyAssignedException {
+            fail("This method should not be called");
         }
 
         @Override

--- a/src/test/java/seedu/club/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/club/logic/commands/ExportCommandTest.java
@@ -55,7 +55,6 @@ import seedu.club.model.task.exceptions.TaskAlreadyAssignedException;
 import seedu.club.model.task.exceptions.TaskCannotBeDeletedException;
 import seedu.club.model.task.exceptions.TaskNotFoundException;
 import seedu.club.model.task.exceptions.TasksAlreadyListedException;
-import seedu.club.model.task.exceptions.TasksCannotBeDisplayedException;
 
 public class ExportCommandTest {
 
@@ -225,7 +224,7 @@ public class ExportCommandTest {
         }
 
         @Override
-        public void viewAllTasks() throws TasksCannotBeDisplayedException {
+        public void viewAllTasks() throws TasksAlreadyListedException {
             fail("This method should not be called");
         }
 

--- a/src/test/java/seedu/club/logic/commands/LogInCommandTest.java
+++ b/src/test/java/seedu/club/logic/commands/LogInCommandTest.java
@@ -44,7 +44,6 @@ import seedu.club.model.task.exceptions.TaskAlreadyAssignedException;
 import seedu.club.model.task.exceptions.TaskCannotBeDeletedException;
 import seedu.club.model.task.exceptions.TaskNotFoundException;
 import seedu.club.model.task.exceptions.TasksAlreadyListedException;
-import seedu.club.model.task.exceptions.TasksCannotBeDisplayedException;
 
 public class LogInCommandTest {
     private final Member member = new Member(new Name("Alex Yeoh"),
@@ -129,7 +128,7 @@ public class LogInCommandTest {
         }
 
         @Override
-        public void viewAllTasks() throws TasksCannotBeDisplayedException {
+        public void viewAllTasks() throws TasksAlreadyListedException {
             fail("This method should not be called");
         }
 

--- a/src/test/java/seedu/club/logic/commands/LogInCommandTest.java
+++ b/src/test/java/seedu/club/logic/commands/LogInCommandTest.java
@@ -40,6 +40,7 @@ import seedu.club.model.tag.Tag;
 import seedu.club.model.tag.exceptions.TagNotFoundException;
 import seedu.club.model.task.Task;
 import seedu.club.model.task.exceptions.DuplicateTaskException;
+import seedu.club.model.task.exceptions.TaskAlreadyAssignedException;
 import seedu.club.model.task.exceptions.TaskCannotBeDeletedException;
 import seedu.club.model.task.exceptions.TaskNotFoundException;
 import seedu.club.model.task.exceptions.TasksAlreadyListedException;
@@ -98,6 +99,12 @@ public class LogInCommandTest {
         @Override
         public void changeStatus(Task taskToEdit, Task editedTask) throws TaskNotFoundException,
                 DuplicateTaskException {
+            fail("This method should not be called");
+        }
+
+        @Override
+        public void changeAssignee(Task taskToEdit, Task editedTask) throws MemberNotFoundException,
+                DuplicateTaskException, TaskAlreadyAssignedException {
             fail("This method should not be called");
         }
 

--- a/src/test/java/seedu/club/logic/commands/SignUpCommandTest.java
+++ b/src/test/java/seedu/club/logic/commands/SignUpCommandTest.java
@@ -40,7 +40,6 @@ import seedu.club.model.task.exceptions.TaskAlreadyAssignedException;
 import seedu.club.model.task.exceptions.TaskCannotBeDeletedException;
 import seedu.club.model.task.exceptions.TaskNotFoundException;
 import seedu.club.model.task.exceptions.TasksAlreadyListedException;
-import seedu.club.model.task.exceptions.TasksCannotBeDisplayedException;
 import seedu.club.testutil.MemberBuilder;
 
 
@@ -268,7 +267,7 @@ public class SignUpCommandTest {
         }
 
         @Override
-        public void viewAllTasks() throws TasksCannotBeDisplayedException {
+        public void viewAllTasks() throws TasksAlreadyListedException {
             fail("This method should not be called");
             return;
         }

--- a/src/test/java/seedu/club/logic/commands/SignUpCommandTest.java
+++ b/src/test/java/seedu/club/logic/commands/SignUpCommandTest.java
@@ -36,6 +36,7 @@ import seedu.club.model.tag.Tag;
 import seedu.club.model.tag.exceptions.TagNotFoundException;
 import seedu.club.model.task.Task;
 import seedu.club.model.task.exceptions.DuplicateTaskException;
+import seedu.club.model.task.exceptions.TaskAlreadyAssignedException;
 import seedu.club.model.task.exceptions.TaskCannotBeDeletedException;
 import seedu.club.model.task.exceptions.TaskNotFoundException;
 import seedu.club.model.task.exceptions.TasksAlreadyListedException;
@@ -70,6 +71,12 @@ public class SignUpCommandTest {
         public void voteInPoll(Poll poll, Index answerIndex) throws
                 PollNotFoundException, AnswerNotFoundException, UserAlreadyVotedException {
             fail("This method should not be called.");
+        }
+
+        @Override
+        public void changeAssignee(Task taskToEdit, Task editedTask) throws MemberNotFoundException,
+                DuplicateTaskException, TaskAlreadyAssignedException {
+            fail("This method should not be called");
         }
 
         @Override

--- a/src/test/java/seedu/club/logic/parser/ChangeAssigneeCommandParserTest.java
+++ b/src/test/java/seedu/club/logic/parser/ChangeAssigneeCommandParserTest.java
@@ -1,0 +1,56 @@
+package seedu.club.logic.parser;
+//@@author yash-chowdhary
+import static seedu.club.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.club.logic.commands.CommandTestUtil.INVALID_MATRIC_NUMBER;
+import static seedu.club.logic.commands.CommandTestUtil.VALID_MATRIC_NUMBER;
+import static seedu.club.logic.commands.CommandTestUtil.VALID_MATRIC_NUMBER_AMY;
+import static seedu.club.logic.commands.CommandTestUtil.VALID_MATRIC_NUMBER_BOB;
+import static seedu.club.logic.parser.CliSyntax.PREFIX_MATRIC_NUMBER;
+import static seedu.club.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.club.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.club.testutil.TypicalIndexes.INDEX_FIRST_TASK;
+import static seedu.club.testutil.TypicalIndexes.INDEX_SECOND_TASK;
+
+import org.junit.Test;
+
+import seedu.club.logic.commands.ChangeAssigneeCommand;
+import seedu.club.model.member.MatricNumber;
+import seedu.club.model.task.Assignee;
+
+public class ChangeAssigneeCommandParserTest {
+    private ChangeAssigneeCommandParser parser = new ChangeAssigneeCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsChangeAssigneeCommand() {
+        assertParseSuccess(parser, " 1 "
+                        + " " + PREFIX_MATRIC_NUMBER + VALID_MATRIC_NUMBER,
+                new ChangeAssigneeCommand(INDEX_FIRST_TASK, new Assignee(VALID_MATRIC_NUMBER)));
+        assertParseSuccess(parser, " 2 "
+                        + " " + PREFIX_MATRIC_NUMBER + VALID_MATRIC_NUMBER_BOB,
+                new ChangeAssigneeCommand(INDEX_SECOND_TASK, new Assignee(VALID_MATRIC_NUMBER_BOB)));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, " a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ChangeAssigneeCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, " one",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ChangeAssigneeCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidIndex_throwsParseException() {
+        assertParseFailure(parser, " -1" + PREFIX_MATRIC_NUMBER + VALID_MATRIC_NUMBER_AMY,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ChangeAssigneeCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, " 0" + PREFIX_MATRIC_NUMBER + VALID_MATRIC_NUMBER_BOB,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ChangeAssigneeCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidStatus_throwsParseException() {
+        // invalid matric number
+        assertParseFailure(parser, " 1 " + PREFIX_MATRIC_NUMBER + INVALID_MATRIC_NUMBER,
+                MatricNumber.MESSAGE_MATRIC_NUMBER_CONSTRAINTS);
+    }
+
+}

--- a/src/test/java/seedu/club/model/ClubBookTest.java
+++ b/src/test/java/seedu/club/model/ClubBookTest.java
@@ -197,7 +197,7 @@ public class ClubBookTest {
         editedTask.setStatus(new Status(Status.IN_PROGRESS_STATUS));
 
         try {
-            clubBook.updateTask(taskToEdit, editedTask);
+            clubBook.updateTaskStatus(taskToEdit, editedTask);
         } catch (DuplicateTaskException | TaskNotFoundException e) {
             fail("This will not be executed");
         }
@@ -221,7 +221,7 @@ public class ClubBookTest {
         Task editedTask = new Task(BUY_FOOD);
 
         try {
-            clubBook.updateTask(taskToEdit, editedTask);
+            clubBook.updateTaskStatus(taskToEdit, editedTask);
         } catch (DuplicateTaskException dte) {
             assertEquals(expectedClubBook, clubBook);
         } catch (TaskNotFoundException tnfe) {

--- a/src/test/java/seedu/club/model/ClubBookTest.java
+++ b/src/test/java/seedu/club/model/ClubBookTest.java
@@ -37,6 +37,7 @@ import seedu.club.model.member.Member;
 import seedu.club.model.poll.Poll;
 import seedu.club.model.tag.Tag;
 import seedu.club.model.tag.exceptions.TagNotFoundException;
+import seedu.club.model.task.Assignee;
 import seedu.club.model.task.Status;
 import seedu.club.model.task.Task;
 import seedu.club.model.task.exceptions.DuplicateTaskException;
@@ -227,6 +228,23 @@ public class ClubBookTest {
         } catch (TaskNotFoundException tnfe) {
             fail("This will not be executed");
         }
+    }
+
+    @Test
+    public void updateTaskAssignee_validAssignee_success() throws Exception {
+        ClubBook clubBook = new ClubBookBuilder().withMember(ALICE)
+                .withMember(BENSON)
+                .withTask(BUY_CONFETTI).withTask(BUY_FOOD).build();
+
+        Task taskToEdit = BUY_FOOD;
+        Task editedTask = new TaskBuilder(BUY_FOOD).build();
+        editedTask.setAssignee(new Assignee(BENSON.getMatricNumber().toString()));
+
+        ClubBook expectedClubBook = new ClubBookBuilder().withMember(ALICE).withMember(BENSON)
+                .withTask(editedTask).withTask(BUY_CONFETTI).build();
+
+        clubBook.updateTaskAssignee(taskToEdit, editedTask);
+        assertEquals(expectedClubBook, clubBook);
     }
     //@@author
 

--- a/src/test/java/seedu/club/model/ModelManagerTest.java
+++ b/src/test/java/seedu/club/model/ModelManagerTest.java
@@ -45,8 +45,10 @@ import seedu.club.model.task.Status;
 import seedu.club.model.task.Task;
 import seedu.club.model.task.TaskIsRelatedToMemberPredicate;
 import seedu.club.model.task.exceptions.DuplicateTaskException;
+import seedu.club.model.task.exceptions.TaskAlreadyAssignedException;
 import seedu.club.model.task.exceptions.TaskCannotBeDeletedException;
 import seedu.club.model.task.exceptions.TaskNotFoundException;
+import seedu.club.model.task.exceptions.TaskStatusCannotBeEditedException;
 import seedu.club.model.task.exceptions.TasksAlreadyListedException;
 import seedu.club.model.task.exceptions.TasksCannotBeDisplayedException;
 import seedu.club.testutil.Assert;
@@ -246,7 +248,7 @@ public class ModelManagerTest {
             modelManager.assignTask(BUY_FOOD, BOB.getMatricNumber());
         } catch (DuplicateTaskException dte) {
             assertEquals(expectedModel, modelManager);
-        } catch (MemberNotFoundException mnfe) {
+        } catch (MemberNotFoundException | TaskAlreadyAssignedException e) {
             fail("This exception should not be caught");
         }
     }
@@ -262,7 +264,7 @@ public class ModelManagerTest {
         expectedModel.logsInMember(AMY.getCredentials().getUsername().value, AMY.getCredentials().getPassword().value);
         try {
             modelManager.assignTask(BUY_CONFETTI, BOB.getMatricNumber());
-        } catch (DuplicateTaskException dte) {
+        } catch (DuplicateTaskException | TaskAlreadyAssignedException e) {
             fail("This exception should not be caught");
         } catch (MemberNotFoundException mnfe) {
             assertEquals(expectedModel, modelManager);
@@ -281,9 +283,7 @@ public class ModelManagerTest {
 
         try {
             modelManager.assignTask(BUY_CONFETTI, BOB.getMatricNumber());
-        } catch (DuplicateTaskException dte) {
-            fail("This exception should not be caught");
-        } catch (MemberNotFoundException mnfe) {
+        } catch (DuplicateTaskException | MemberNotFoundException | TaskAlreadyAssignedException e) {
             fail("This exception should not be caught");
         }
     }
@@ -324,7 +324,7 @@ public class ModelManagerTest {
 
         try {
             modelManager.changeStatus(taskToEdit, editedTask);
-        } catch (TaskNotFoundException | DuplicateTaskException e) {
+        } catch (TaskNotFoundException | DuplicateTaskException | TaskStatusCannotBeEditedException e) {
             assertEquals(expectedModel, modelManager);
         }
 
@@ -348,7 +348,7 @@ public class ModelManagerTest {
 
         try {
             modelManager.changeStatus(taskToEdit, editedTask);
-        } catch (DuplicateTaskException | TaskNotFoundException e) {
+        } catch (DuplicateTaskException | TaskNotFoundException | TaskStatusCannotBeEditedException e) {
             assertEquals(expectedModel, modelManager);
         }
     }
@@ -369,9 +369,12 @@ public class ModelManagerTest {
 
         try {
             modelManager.changeStatus(taskToEdit, editedTask);
+        } catch (TaskStatusCannotBeEditedException e) {
+            assertEquals(expectedModel, modelManager);
         } catch (TaskNotFoundException | DuplicateTaskException e) {
-            fail("This will not be executed");
+            fail("This will not execute");
         }
+
     }
 
     @Test


### PR DESCRIPTION
fixes #200 
`EXCO` members can change the `Assignee` of a command.
Checks for duplicate tasks, invalid assignees, unchanged assignee, and assigning it to a person who already has a similar task assigned are in place.
Tests added.